### PR TITLE
Fix for missing repositories

### DIFF
--- a/src/repos.js
+++ b/src/repos.js
@@ -4,9 +4,22 @@ const api = require('./api');
 const blacklist = ['rfcs'];
 
 const getForOrg = async org => {
-  const {data} = await api.repos.getForOrg({
-    org: org,
-  });
+  let pageNum = 1;
+  let results = [];
+  let isEmpty = false;
+  while (!isEmpty) {
+    const {data} = await api.repos.getForOrg({
+      org: org,
+      page: pageNum,
+    });
+    results.push(data);
+
+    pageNum++;
+    isEmpty = data.length === 0;
+  }
+
+  const data = [].concat.apply([], results);
+  console.log(data.map(d => d.name));
   return data.filter(item => !blacklist.includes(item.name)).map(item => {
     return {
       upstream: org,

--- a/src/repos.js
+++ b/src/repos.js
@@ -19,7 +19,6 @@ const getForOrg = async org => {
   }
 
   const data = [].concat.apply([], results);
-  console.log(data.map(d => d.name));
   return data.filter(item => !blacklist.includes(item.name)).map(item => {
     return {
       upstream: org,


### PR DESCRIPTION
Fixes #35

> Some repositories, like fusion-plugin-font-loader-react do not appear to be included in any of the fusion-orchestrate commands when they should be.
