### PR TITLE
Remove deprecated followRedirects option

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -5,7 +5,6 @@ const github = new GitHubApi({
   timeout: 5000,
   host: 'api.github.com',
   protocol: 'https',
-  followRedirects: true,
   rejectUnauthorized: false,
 });
 


### PR DESCRIPTION
This will help squelch log output a bit.